### PR TITLE
ci(github-actions): add workflow for Claude Code integration

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,45 @@
+name: Claude Code
+on:
+    issue_comment:
+        types: [created]
+    pull_request_review_comment:
+        types: [created]
+    issues:
+        types: [opened, assigned]
+    pull_request_review:
+        types: [submitted]
+
+jobs:
+    claude:
+        if: |
+            github.repository_owner == github.actor &&
+            (
+                (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+                (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+                (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+                (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+            )
+
+        runs-on: ubuntu-latest
+
+        permissions:
+            contents: write
+            pull-requests: write
+            issues: write
+            id-token: write
+
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v4
+              with:
+                  fetch-depth: 1
+
+            - name: Run Claude Code
+              id: claude
+              uses: nanasess/claude-code-action@main
+              with:
+                  use_oauth: 'true'
+                  claude_access_token: ${{ secrets.CLAUDE_ACCESS_TOKEN }}
+                  claude_refresh_token: ${{ secrets.CLAUDE_REFRESH_TOKEN }}
+                  claude_expires_at: ${{ secrets.CLAUDE_EXPIRES_AT }}
+                  allowed_tools: "Bash,mcp__github_file_ops__update_issue_comment"


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to integrate Claude, an AI tool, for handling specific events within the repository. The workflow is triggered by various events such as issue comments, pull request review comments, and issues, and executes only when the actor matches the repository owner and mentions "@claude" in the event content.

### New GitHub Actions Workflow:

* **Workflow Name and Triggers**: Added a new workflow named `Claude Code` in `.github/workflows/claude.yml`. This workflow is triggered by events like `issue_comment`, `pull_request_review_comment`, `issues`, and `pull_request_review` when "@claude" is mentioned in the event body or title.

* **Job Configuration**: Defined a `claude` job that runs on `ubuntu-latest` with specific permissions (`contents`, `pull-requests`, `issues`, and `id-token` set to write). The job ensures the workflow is executed only if the repository owner matches the actor and the "@claude" condition is satisfied.

* **Steps**:
  - **Repository Checkout**: Uses the `actions/checkout@v4` action to fetch the repository with a depth of 1.
  - **Claude Code Execution**: Runs the `nanasess/claude-code-action@main` action with OAuth tokens and allowed tools specified via